### PR TITLE
docs: fix typo in description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["parser-implementations"]
 keywords = ["iso6709", "latlon", "coordinates", "parse", "gps"]
 repository = "https://github.com/TimLikesTacos/iso6709parse.git"
 readme = "README.md"
-description = "Parses coorindates in ISO6709 format from strings"
+description = "Parses coordinates in ISO6709 format from strings"
 [dependencies]
 nom = "7"
 geo-types = "0.7"


### PR DESCRIPTION
Hi @TimLikesTacos: I noticed this typo while on [crates.io](https://crates.io/crates/iso6709parse). Cheers!